### PR TITLE
join_mutate() using vec_ptype_common() instead of vec_ptype2() (#4863)

### DIFF
--- a/R/join.r
+++ b/R/join.r
@@ -329,7 +329,7 @@ join_mutate <- function(x, y, by, type,
   out <- vec_slice(out, c(rows$x, rep_along(rows$y_extra, NA_integer_)))
 
   if (!keep) {
-    out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype2(x_key, y_key))
+    out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype_common(x_key, y_key))
     new_rows <- length(rows$x) + seq_along(rows$y_extra)
     out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
   }

--- a/tests/testthat/test-join.r
+++ b/tests/testthat/test-join.r
@@ -119,8 +119,6 @@ test_that("joins don't match NA when na_matches = 'never' (#2033)", {
   df1 <- tibble(a = NA)
   df2 <- tibble(a = NA, b = 1:3)
   expect_warning(left_join(df1, df2, by = "a", na_matches = "never"))
-
-  skip("until https://github.com/r-lib/vctrs/issues/718")
 })
 
 # nest_join ---------------------------------------------------------------


### PR DESCRIPTION
* Using vec_ptype_common() instead of vec_ptype2().